### PR TITLE
Add error display when recipe cannot be loaded, instead of crashing site

### DIFF
--- a/app/src/components/RecipeError/RecipeError.tsx
+++ b/app/src/components/RecipeError/RecipeError.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { Paper, Typography } from "@mui/material";
+
+const RecipeError = () => {
+  return (
+    <Paper
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        padding: "20px",
+        marginTop: "200px",
+      }}
+      elevation={8}
+    >
+      <Typography sx={{ color: "red" }} variant="h5">
+        Cannot display recipe
+      </Typography>
+    </Paper>
+  );
+};
+export default RecipeError;

--- a/app/src/screens/Recipe/Recipe.tsx
+++ b/app/src/screens/Recipe/Recipe.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import "./Recipe.css";
 import { useLocation } from "react-router-dom";
 import InstructionStepper from "../../components/InstructionStepper/InstructionStepper";
+import RecipeError from "../../components/RecipeError/RecipeError";
 import { List, ListItem, ListItemText, Paper, Checkbox } from "@mui/material";
 import {
   getIngredients,
@@ -18,6 +19,8 @@ function Recipe() {
   >([]);
   const [userIngredientElements, setUserIngredientElements] =
     React.useState<any>();
+
+  if (!useLocation().state) return <RecipeError />;
 
   const recipe = useLocation().state.recipe;
   const imperialIngredients = recipe["Ingredients"]


### PR DESCRIPTION
Fixes #36 

When trying to access a recipe directly via the recipe URL, the site now displays an error instead of the whole site crashing. For example, trying to access this url
```http://localhost:3000/recipes/Cream%20of%20Tomato%20Soup%20Recipe%20```
would crash the site. This was because the recipe data was passed as a state which only exists if it's accessed from the recipes page. There were also some rare cases where the site would crash even if the recipe was accessed through the recipes page.

![image](https://github.com/JakobPaulsson/EasyEats/assets/54035323/e8ebdbf1-dbab-4ba4-9c0e-36e122e50c32)
