### PR TITLE
Remove settings page from sidebar and rename the account page to presets

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,7 +4,7 @@ import Login from "./screens/Login/Login";
 import Signup from "./screens/Signup/Signup";
 import Dashboard from "./screens/Dashboard/Dashboard";
 import Ingredients from "./screens/Ingredients/Ingredients";
-import Account from "./screens/Account/Account";
+import Presets from "./screens/Presets/Presets";
 import Sidebar from "./components/SideBar/Sidebar";
 import Header from "./components/Header/Header";
 import Recipe from "./screens/Recipe/Recipe";
@@ -33,7 +33,7 @@ function App() {
           <Route path="/ingredients" element={<Ingredients />} />
           <Route path="/recipes/:recipeid" element={<Recipe />} />
           <Route path="/recipes/page/:pageNumber" element={<Recipes />} />
-          <Route path="/account" element={<Account />} />
+          <Route path="/presets" element={<Presets />} />
         </Routes>
       </div>
     </div>

--- a/app/src/components/SideBar/Sidebar.tsx
+++ b/app/src/components/SideBar/Sidebar.tsx
@@ -11,23 +11,20 @@ import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
-
-import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutIcon from "@mui/icons-material/Logout";
 import DashboardIcon from "@mui/icons-material/Dashboard";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
 import KitchenIcon from "@mui/icons-material/Kitchen";
-import AccountCircleIcon from "@mui/icons-material/AccountCircle";
+import TuneIcon from "@mui/icons-material/Tune";
 
-import { useNavigate, useLocation, useParams } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 const drawerWidth = 240;
 const sideBarRoutes: Record<string, string> = {
   Dashboard: "/dasboard",
   Ingredients: "/ingredients",
   Recipes: "/recipes/page/1",
-  Account: "/account",
-  Settings: "/",
+  Presets: "/presets",
   Logout: "/",
 };
 
@@ -35,7 +32,7 @@ const sideBarIcons: Record<string, JSX.Element> = {
   Dashboard: <DashboardIcon />,
   Recipes: <MenuBookIcon />,
   Ingredients: <KitchenIcon />,
-  Account: <AccountCircleIcon />,
+  Presets: <TuneIcon />,
 };
 
 export default function Sidebar() {
@@ -83,7 +80,7 @@ export default function Sidebar() {
         <img src={"/logo.png"} alt="logo" />
         <Divider />
         <List>
-          {["Dashboard", "Recipes", "Ingredients", "Account"].map((text) => (
+          {["Dashboard", "Recipes", "Ingredients", "Presets"].map((text) => (
             <ListItem data-cy={text} key={text} disablePadding>
               <ListItemButton
                 onClick={(event: React.SyntheticEvent) => {
@@ -99,21 +96,19 @@ export default function Sidebar() {
         </List>
         <Divider />
         <List>
-          {["Settings", "Logout"].map((text, index) => (
-            <ListItem key={text} disablePadding>
-              <ListItemButton
-                onClick={(event: React.SyntheticEvent) => {
-                  const clickedElement = event.target as HTMLElement;
-                  handleSideBarClick(clickedElement.innerText);
-                }}
-              >
-                <ListItemIcon>
-                  {index % 2 === 0 ? <SettingsIcon /> : <LogoutIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          ))}
+          <ListItem key={"Logout"} disablePadding>
+            <ListItemButton
+              onClick={(event: React.SyntheticEvent) => {
+                const clickedElement = event.target as HTMLElement;
+                handleSideBarClick(clickedElement.innerText);
+              }}
+            >
+              <ListItemIcon>
+                <LogoutIcon />
+              </ListItemIcon>
+              <ListItemText primary={"Logout"} />
+            </ListItemButton>
+          </ListItem>
         </List>
       </Drawer>
     </Box>

--- a/app/src/screens/Presets/Presets.tsx
+++ b/app/src/screens/Presets/Presets.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import "./Account.css";
+import "./Presets.css";
 import CustomPreset from "../../components/CustomPreset/CustomPreset";
 import { PresetSelector } from "../../components/PresetSelector/PresetSelector";
 import Box from "@mui/material/Box";
@@ -38,7 +38,7 @@ function a11yProps(index: number) {
   };
 }
 
-function Account() {
+function Presets() {
   const [value, setValue] = React.useState(0);
 
   const handleChange = (_: React.SyntheticEvent, newValue: number) => {
@@ -97,4 +97,4 @@ function Account() {
   );
 }
 
-export default Account;
+export default Presets;


### PR DESCRIPTION
Fixes #56 
Fixes #57 


Old sidebar             |  New sidebar
:-------------------------:|:-------------------------:
![image](https://github.com/JakobPaulsson/EasyEats/assets/54035323/94ca25f6-bd12-4988-b5e5-50af4aa98a50)  |  ![image](https://github.com/JakobPaulsson/EasyEats/assets/54035323/1287a1b7-0c99-4ac8-9cab-c6a885ca273f)
